### PR TITLE
Add Em Dash inline markdown editor

### DIFF
--- a/em-dash.css
+++ b/em-dash.css
@@ -1,0 +1,51 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Poppins", sans-serif;
+    background: #fafafa;
+    color: #1d1d1f;
+}
+
+.container {
+    max-width: 760px;
+    margin: 40px auto;
+    padding: 0 20px 40px;
+}
+
+.header h1 {
+    margin-bottom: 8px;
+    font-size: 2rem;
+}
+
+.header p {
+    margin-top: 0;
+    color: #555;
+}
+
+.editor {
+    min-height: 60vh;
+    border: 1px solid #dcdcdc;
+    border-radius: 12px;
+    padding: 18px;
+    background: #fff;
+    line-height: 1.7;
+    outline: none;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.editor:empty::before {
+    content: attr(data-placeholder);
+    color: #9a9a9a;
+}
+
+.footer {
+    margin-top: 16px;
+}
+
+.footer a {
+    text-decoration: none;
+    color: #444;
+}

--- a/em-dash.html
+++ b/em-dash.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Em Dash Editor</title>
+    <link rel="stylesheet" href="em-dash.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600&display=swap">
+</head>
+<body>
+    <main class="container">
+        <header class="header">
+            <h1>Em Dash</h1>
+            <p>Inline markdown editor that quietly formats as you type.</p>
+        </header>
+        <div
+            class="editor"
+            id="editor"
+            contenteditable="true"
+            role="textbox"
+            aria-multiline="true"
+            data-placeholder="Start writing with markdown...">
+        </div>
+        <footer class="footer">
+            <a href="index.html">Back to home</a>
+        </footer>
+    </main>
+    <script src="em-dash.js"></script>
+</body>
+</html>

--- a/em-dash.js
+++ b/em-dash.js
@@ -1,0 +1,191 @@
+const editor = document.getElementById("editor");
+let isApplying = false;
+
+const inlineRules = [
+    { pattern: /\*\*\*([^*]+)\*\*\*/g, replacement: "<strong><em>$1</em></strong>" },
+    { pattern: /\*\*([^*]+)\*\*/g, replacement: "<strong>$1</strong>" },
+    { pattern: /\*([^*]+)\*/g, replacement: "<em>$1</em>" },
+    { pattern: /_([^_]+)_/g, replacement: "<em>$1</em>" }
+];
+
+editor.addEventListener("input", (event) => {
+    if (isApplying) {
+        return;
+    }
+
+    if (event.data === " ") {
+        if (applyBlockFormatting()) {
+            return;
+        }
+    }
+
+    isApplying = true;
+    const marker = insertCaretMarker();
+    applyInlineFormatting();
+    restoreCaret(marker);
+    isApplying = false;
+});
+
+function applyBlockFormatting() {
+    const selection = window.getSelection();
+    if (!selection.rangeCount) {
+        return false;
+    }
+
+    const anchor = selection.anchorNode;
+    const block = findBlockElement(anchor);
+    if (!block || block === editor) {
+        return false;
+    }
+
+    const rawText = block.textContent.replace(/\u200B/g, "");
+    const headingMatch = rawText.match(/^(#{1,3})\s/);
+    const blockquoteMatch = rawText.match(/^>\s/);
+    const unorderedMatch = rawText.match(/^-\s/);
+    const orderedMatch = rawText.match(/^(\d+)\.\s/);
+
+    if (headingMatch) {
+        const level = headingMatch[1].length;
+        const content = rawText.slice(level + 1);
+        replaceBlock(block, `h${level}`, content);
+        return true;
+    }
+
+    if (blockquoteMatch) {
+        const content = rawText.slice(2);
+        replaceBlock(block, "blockquote", content);
+        return true;
+    }
+
+    if (unorderedMatch) {
+        const content = rawText.slice(2);
+        replaceWithList(block, "ul", content);
+        return true;
+    }
+
+    if (orderedMatch) {
+        const content = rawText.slice(orderedMatch[0].length);
+        replaceWithList(block, "ol", content);
+        return true;
+    }
+
+    return false;
+}
+
+function applyInlineFormatting() {
+    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT, {
+        acceptNode: (node) => {
+            if (!node.nodeValue || !node.nodeValue.trim()) {
+                return NodeFilter.FILTER_SKIP;
+            }
+            if (node.parentElement && node.parentElement.closest("strong, em, [data-caret]")) {
+                return NodeFilter.FILTER_SKIP;
+            }
+            return NodeFilter.FILTER_ACCEPT;
+        }
+    });
+
+    const textNodes = [];
+    while (walker.nextNode()) {
+        textNodes.push(walker.currentNode);
+    }
+
+    textNodes.forEach((node) => {
+        const escaped = escapeHtml(node.nodeValue);
+        let formatted = escaped;
+        inlineRules.forEach((rule) => {
+            formatted = formatted.replace(rule.pattern, rule.replacement);
+        });
+
+        if (formatted !== escaped) {
+            const wrapper = document.createElement("span");
+            wrapper.innerHTML = formatted;
+            const fragment = document.createDocumentFragment();
+            while (wrapper.firstChild) {
+                fragment.appendChild(wrapper.firstChild);
+            }
+            node.replaceWith(fragment);
+        }
+    });
+}
+
+function findBlockElement(node) {
+    let current = node;
+    while (current && current !== editor) {
+        if (current.nodeType === Node.ELEMENT_NODE) {
+            const tag = current.tagName.toLowerCase();
+            if (["div", "p", "h1", "h2", "h3", "blockquote", "li"].includes(tag)) {
+                return current;
+            }
+        }
+        current = current.parentNode;
+    }
+    return null;
+}
+
+function replaceBlock(block, tag, content) {
+    const element = document.createElement(tag);
+    element.textContent = content;
+    block.replaceWith(element);
+    placeCaretAtEnd(element);
+}
+
+function replaceWithList(block, listTag, content) {
+    const parentList = block.parentElement;
+    if (block.tagName && block.tagName.toLowerCase() === "li" && parentList && parentList.tagName.toLowerCase() === listTag) {
+        block.textContent = content;
+        placeCaretAtEnd(block);
+        return;
+    }
+
+    const list = document.createElement(listTag);
+    const item = document.createElement("li");
+    item.textContent = content;
+    list.appendChild(item);
+    block.replaceWith(list);
+    placeCaretAtEnd(item);
+}
+
+function insertCaretMarker() {
+    const selection = window.getSelection();
+    if (!selection.rangeCount) {
+        return null;
+    }
+    const range = selection.getRangeAt(0);
+    const marker = document.createElement("span");
+    marker.setAttribute("data-caret", "true");
+    marker.appendChild(document.createTextNode("\u200B"));
+    range.insertNode(marker);
+    return marker;
+}
+
+function restoreCaret(marker) {
+    if (!marker || !marker.parentNode) {
+        return;
+    }
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(marker.firstChild, 1);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    marker.remove();
+}
+
+function placeCaretAtEnd(element) {
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    range.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(range);
+}
+
+function escapeHtml(value) {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/\"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}

--- a/index.html
+++ b/index.html
@@ -70,6 +70,12 @@
                 <p>Typed '2.7 million USD' and got 230799747.60? Mentally enjoying adding commas and converting it to words? Or… just use this easy converter and see '₹23 crores 7 lakhs' instantly.</p>
                 </div>
             </a>
+            <a href="em-dash.html" style="text-decoration: none; color: inherit;">
+                <div class="project-item">
+                <h3>Em Dash</h3>
+                <p>Inline markdown editor that auto-formats headings, lists, quotes, and emphasis as you type.</p>
+                </div>
+            </a>
             <!-- Add more project items here if needed -->
             </section>
         </main>


### PR DESCRIPTION
### Motivation
- Provide a very minimal, focused inline markdown editor that formats as you type (headings, lists, blockquotes, emphasis).
- Keep CSS minimal and centered on the editor UX so parsing/formatting can be iterated independently.
- Preserve caret/selection while transforming content so typing feels natural.
- Make the tool discoverable by linking it from the homepage projects list.

### Description
- Add `em-dash.html` which contains a contenteditable editor, header, and footer with a back link to the homepage.
- Add `em-dash.css` with compact styles for layout, editor appearance, and a placeholder behavior for empty editor state.
- Add `em-dash.js` implementing inline formatting rules and block formatting on space, including heading/list/blockquote detection, inline emphasis (`***`, `**`, `*`, and `_`), caret marker insertion, and caret restoration.
- Update `index.html` to add a project link to the new `em-dash.html` page.

### Testing
- Started a local server with `python -m http.server 8000` and served the site successfully.
- Ran a Playwright script to open `em-dash.html` and capture a screenshot, which completed successfully.
- No automated unit tests were added for the parsing logic in this change.
- Project builds are static HTML/CSS/JS and the new pages load without runtime errors in the headless browser test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69611085865c832891c083505826d07f)